### PR TITLE
feat/#67 - 단어장 생성 시 채팅 메시지 조회 senderId 수정

### DIFF
--- a/src/main/java/org/example/howareyou/domain/chat/voca/dto/ChatMessageReadModel.java
+++ b/src/main/java/org/example/howareyou/domain/chat/voca/dto/ChatMessageReadModel.java
@@ -13,7 +13,8 @@ public class ChatMessageReadModel {
     @Id
     private final String id;
     private final String chatRoomUuid;
-    private final String sender;
+    private final String senderId;
+    private final String senderName;
     private final String content;
     private final Instant messageTime;
 }

--- a/src/main/java/org/example/howareyou/domain/chat/voca/service/ChatMessageVocaServiceImpl.java
+++ b/src/main/java/org/example/howareyou/domain/chat/voca/service/ChatMessageVocaServiceImpl.java
@@ -27,7 +27,8 @@ public class ChatMessageVocaServiceImpl implements ChatMessageVocaService {
         return ChatMessageReadModel.builder()
                 .id(doc.getId())
                 .chatRoomUuid(doc.getChatRoomUuid())
-                .sender(doc.getSenderName())
+                .senderId(doc.getSenderId())
+                .senderName(doc.getSenderName())
                 .content(doc.getContent())
                 .messageTime(doc.getMessageTime())
                 .build();

--- a/src/main/java/org/example/howareyou/domain/vocabulary/dto/MessageItem.java
+++ b/src/main/java/org/example/howareyou/domain/vocabulary/dto/MessageItem.java
@@ -3,6 +3,7 @@ package org.example.howareyou.domain.vocabulary.dto;
 public record MessageItem(
         String messageId,
         String content,
-        String sender,
+        String senderId,
+        String senderName,
         String messageTime
 ) {}

--- a/src/main/java/org/example/howareyou/domain/vocabulary/scheduler/VocaScheduler.java
+++ b/src/main/java/org/example/howareyou/domain/vocabulary/scheduler/VocaScheduler.java
@@ -23,7 +23,7 @@ public class VocaScheduler {
         Instant now = Instant.now();
         Instant oneHourAgo = now.minus(1, ChronoUnit.HOURS);
 
-        log.info("[VocaScheduler] 단어장 생성 시작 - {} ~ {}", oneHourAgo, now);
+        log.info("채팅방 별 단어장 생성 시작 - {} ~ {}", oneHourAgo, now);
 
         chatVocaBookService.generateVocabularyForRangeReactive(oneHourAgo, now)
                 .subscribe(

--- a/src/main/java/org/example/howareyou/domain/vocabulary/service/ChatVocaBookService.java
+++ b/src/main/java/org/example/howareyou/domain/vocabulary/service/ChatVocaBookService.java
@@ -101,7 +101,8 @@ public class ChatVocaBookService {
                         .map(m -> new MessageItem(
                                 m.getId(),
                                 m.getContent(),
-                                m.getSender(),
+                                m.getSenderId(),
+                                m.getSenderName(),
                                 m.getMessageTime().toString()
                         ))
                         .toList()

--- a/src/main/java/org/example/howareyou/global/test/VocaTestController.java
+++ b/src/main/java/org/example/howareyou/global/test/VocaTestController.java
@@ -82,7 +82,10 @@ public class VocaTestController {
         try {
             for (Map<String, Object> req : requests) {
                 String chatRoomUuid = (String) req.get("chatRoomUuid");
+                String senderId = (String) req.get("senderId");
                 String senderName = (String) req.get("senderName");
+                String receiverId = (String) req.get("receiverId");
+                String receiverName = (String) req.get("receiverName");
                 String content = (String) req.get("content");
                 String status = (String) req.getOrDefault("status", "UNREAD");
                 String isoTime = (String) req.getOrDefault("messageTime", Instant.now().toString());
@@ -94,7 +97,10 @@ public class VocaTestController {
 
                 ChatMessageDocument message = ChatMessageDocument.builder()
                         .chatRoomUuid(chatRoomUuid)
+                        .senderId(senderId)
                         .senderName(senderName)
+                        .receiverId(receiverId)
+                        .receiverName(receiverName)
                         .content(content)
                         .messageTime(Instant.parse(isoTime))
                         .chatMessageStatus(ChatMessageStatus.valueOf(status))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 채팅 메시지와 단어장 항목에서 발신자 정보를 ‘발신자 ID’와 ‘발신자 이름’으로 분리해 표시합니다.

* 개선
  * 스케줄러 실행 로그 문구를 더 명확하게 정비했습니다.

* 테스트
  * 테스트용 데이터 생성에서 발신자/수신자 ID 및 이름 입력을 추가로 수용합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->